### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN update-rc.d sendmail defaults
 # ------------------------------------------------------------------------------
 # Install Owncloud
 RUN curl -k https://download.owncloud.org/community/owncloud-7.0.2.tar.bz2 | tar jx -C /var/www/
-RUN chown -R www-data:www-data /var/www/owncloud
 RUN mkdir /var/www/owncloud/data
+RUN chown -R www-data:www-data /var/www/owncloud
 RUN chmod -R 770 /var/www/owncloud/data
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Original lines:
RUN chown -R www-data:www-data /var/www/owncloud 
RUN mkdir /var/www/owncloud/data 
RUN chmod -R 770 /var/www/owncloud/data

You create /var/www/owncloud/data after setting the chown therefore data is created without proper owner.